### PR TITLE
Fix travis caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
       bundler: true
       cocoapods: true
       directories: # Cache opencv with dependecies
-        - /usr/local/opt/opencv@2
+        - /usr/local/opt/
         - /usr/local/Cellar/opencv@2
         - /usr/local/Cellar/ffmpeg
         - /usr/local/Cellar/ilmbase

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,20 @@ stages:
   - deploy
 matrix:
   include:
-    name: Mac OS
+  - stage: test
+    name: Check dependencies up-to-date, Lint
+    env: CACHE_NAME=iOS
+    script:
+        - bundle exec pod update --project-directory=Example
+        - git diff --exit-code # Outdated Cocoapods dependencies found, please run 'pod update' and checkin changes
+        - bundle update
+        - git diff --exit-code # Outdated Bundle dependencies found, please run 'bundle update' and checkin changes
+        - bundle exec pod lib lint || bundle exec pod lib lint --verbose --no-clean
+  - name: With coverage report
+    env: XCODE_DESNITATION='platform=iOS Simulator,name=iPhone X' CACHE_NAME=iOS
+    after_success:
+      - bash <(curl -s 'https://codecov.io/bash') -Z -J '^PerspectiveTransform$' -X gcov -X fix
+  - name: Mac OS
     xcode_scheme: OpenCV Tests
     env: XCODE_DESNITATION='platform=macos' CACHE_NAME=macOS
     before_script: ./Example/OpenCV-OSX-Tests/install-opencv.sh
@@ -43,11 +56,36 @@ matrix:
         - /usr/local/Cellar/openssl
         - /usr/local/Cellar/x264
         - /usr/local/Cellar/x265
+  - stage: deploy
+    name: Cartage build, archive, deploy on tag
+    env:
+    cache: false
+    script:
+      - brew update > /dev/null
+      - brew outdated carthage || brew upgrade carthage
+      - carthage build --no-skip-current --platform iOS
+      - carthage archive PerspectiveTransform
+    deploy:
+      provider: releases
+      prerelease: true
+      name: "Release $TRAVIS_TAG"
+      body: "Travis build: https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID} started by ${TRAVIS_EVENT_TYPE}"
+      skip_cleanup: true
+      api_key:
+        secure: FNzPtWJ1wxgE3LITPT4CSTKboxeJF5tO0SznHMC/pswZeJ7KESZFsRZE0BiPalHT58o7sjW5bjI5GjjTnwLNHC1GpHdH1VRtIPqZF0K6WSfjeZoK5uEURWE3nego4J+h0C9DoQLdvjKwkW9Zw4OvIL1ZLhrqzbix6dcL0M1EGcoavDgkx8c5dsrtOAgafI3owp/RO1JQhPIzKrMwtLNNVHVJthU2ZmOrEngnJhN58hOu+tlcvYmIQvcgqF3S/zUAfsTictc5SiVEezH+lXiDKO361vh5InEMv/+Y9qXM/hZGG1PGdLGGwnVQ9jw2U4SfXNGrudnSxDzbyXLUxE0jeTadX+J9QHOQTaHv2uRevZI4Ok1YFQi/8L+/QSOBSQ1hAeLtvpJ2mGCW5iETbW3KhgShgvexF6tCAEePXIZA0bU9YcTTA0N5R6R09AcZA/jkOoOmwveN00vBsEBfgaEuFOshSPXMCsDl/UMiniU0Xmk47U8ABjAUW3381bMBhiA42Mue8S6bSkZdAoZTuQ/FZSOa4CyeOY6b1dv+kk2Y3rcXK5MmuDypcd2HHDNIWMCAa8zxlyFOd9eZZ2+jNf5XGSudiztMVqoUkosa3WY22GX1cWnRQELuzzAXztv1C6Gckxog4rdU1/U47yhCzYTQqjmwm0b5YqM+Fmsi2uQaOew=
+      file: PerspectiveTransform.framework.zip
+      on:
+        repo: paulz/PerspectiveTransform
+        tags: true
 before_install:
   - bundle -v || gem install bundler
   - ls -la Example/Pods/Manifest.lock && echo Skipping cocoapods repo update || git -C ~/.cocoapods/repos/master/ pull --quiet
 script:
   - set -o pipefail && xcodebuild test -workspace "$TRAVIS_XCODE_WORKSPACE" -scheme "$TRAVIS_XCODE_SCHEME" -destination "$XCODE_DESNITATION" | bundle exec xcpretty -f `bundle exec xcpretty-travis-formatter`
+env:
+  - XCODE_DESNITATION='platform=iOS Simulator,name=iPhone SE' CACHE_NAME=iOS
+  - XCODE_DESNITATION='platform=iOS Simulator,name=iPhone 8 Plus' CACHE_NAME=iOS
+  - XCODE_DESNITATION='platform=iOS Simulator,name=iPhone 8' CACHE_NAME=iOS
 branches:
   except:
   - circleci

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ matrix:
     name: Mac OS
     xcode_scheme: OpenCV Tests
     env: XCODE_DESNITATION='platform=macos' CACHE_NAME=macOS
-    before_script:
-      - ./Example/OpenCV-OSX-Tests/install-opencv.sh
+    before_script: ./Example/OpenCV-OSX-Tests/install-opencv.sh
     cache:
       bundler: true
       cocoapods: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
       bundler: true
       cocoapods: true
       directories: # Cache opencv with dependecies
-        - /usr/local/opt/opencv@2/
+        - /usr/local/opt/opencv@2
         - /usr/local/Cellar/opencv@2
         - /usr/local/Cellar/ffmpeg
         - /usr/local/Cellar/ilmbase

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,7 @@ stages:
   - deploy
 matrix:
   include:
-  - stage: test
-    name: Check dependencies up-to-date, Lint
-    env: CACHE_NAME=iOS
-    script:
-        - bundle exec pod update --project-directory=Example
-        - git diff --exit-code # Outdated Cocoapods dependencies found, please run 'pod update' and checkin changes
-        - bundle update
-        - git diff --exit-code # Outdated Bundle dependencies found, please run 'bundle update' and checkin changes
-        - bundle exec pod lib lint || bundle exec pod lib lint --verbose --no-clean
-  - name: With coverage report
-    env: XCODE_DESNITATION='platform=iOS Simulator,name=iPhone X' CACHE_NAME=iOS
-    after_success:
-      - bash <(curl -s 'https://codecov.io/bash') -Z -J '^PerspectiveTransform$' -X gcov -X fix
-  - name: Mac OS
+    name: Mac OS
     xcode_scheme: OpenCV Tests
     env: XCODE_DESNITATION='platform=macos' CACHE_NAME=macOS
     before_script:
@@ -57,36 +44,11 @@ matrix:
         - /usr/local/Cellar/openssl
         - /usr/local/Cellar/x264
         - /usr/local/Cellar/x265
-  - stage: deploy
-    name: Cartage build, archive, deploy on tag
-    env:
-    cache: false
-    script:
-      - brew update > /dev/null
-      - brew outdated carthage || brew upgrade carthage
-      - carthage build --no-skip-current --platform iOS
-      - carthage archive PerspectiveTransform
-    deploy:
-      provider: releases
-      prerelease: true
-      name: "Release $TRAVIS_TAG"
-      body: "Travis build: https://travis-ci.org/${TRAVIS_REPO_SLUG}/jobs/${TRAVIS_JOB_ID} started by ${TRAVIS_EVENT_TYPE}"
-      skip_cleanup: true
-      api_key:
-        secure: FNzPtWJ1wxgE3LITPT4CSTKboxeJF5tO0SznHMC/pswZeJ7KESZFsRZE0BiPalHT58o7sjW5bjI5GjjTnwLNHC1GpHdH1VRtIPqZF0K6WSfjeZoK5uEURWE3nego4J+h0C9DoQLdvjKwkW9Zw4OvIL1ZLhrqzbix6dcL0M1EGcoavDgkx8c5dsrtOAgafI3owp/RO1JQhPIzKrMwtLNNVHVJthU2ZmOrEngnJhN58hOu+tlcvYmIQvcgqF3S/zUAfsTictc5SiVEezH+lXiDKO361vh5InEMv/+Y9qXM/hZGG1PGdLGGwnVQ9jw2U4SfXNGrudnSxDzbyXLUxE0jeTadX+J9QHOQTaHv2uRevZI4Ok1YFQi/8L+/QSOBSQ1hAeLtvpJ2mGCW5iETbW3KhgShgvexF6tCAEePXIZA0bU9YcTTA0N5R6R09AcZA/jkOoOmwveN00vBsEBfgaEuFOshSPXMCsDl/UMiniU0Xmk47U8ABjAUW3381bMBhiA42Mue8S6bSkZdAoZTuQ/FZSOa4CyeOY6b1dv+kk2Y3rcXK5MmuDypcd2HHDNIWMCAa8zxlyFOd9eZZ2+jNf5XGSudiztMVqoUkosa3WY22GX1cWnRQELuzzAXztv1C6Gckxog4rdU1/U47yhCzYTQqjmwm0b5YqM+Fmsi2uQaOew=
-      file: PerspectiveTransform.framework.zip
-      on:
-        repo: paulz/PerspectiveTransform
-        tags: true
 before_install:
   - bundle -v || gem install bundler
   - ls -la Example/Pods/Manifest.lock && echo Skipping cocoapods repo update || git -C ~/.cocoapods/repos/master/ pull --quiet
 script:
   - set -o pipefail && xcodebuild test -workspace "$TRAVIS_XCODE_WORKSPACE" -scheme "$TRAVIS_XCODE_SCHEME" -destination "$XCODE_DESNITATION" | bundle exec xcpretty -f `bundle exec xcpretty-travis-formatter`
-env:
-  - XCODE_DESNITATION='platform=iOS Simulator,name=iPhone SE' CACHE_NAME=iOS
-  - XCODE_DESNITATION='platform=iOS Simulator,name=iPhone 8 Plus' CACHE_NAME=iOS
-  - XCODE_DESNITATION='platform=iOS Simulator,name=iPhone 8' CACHE_NAME=iOS
 branches:
   except:
   - circleci

--- a/Example/OpenCV-OSX-Tests/install-opencv.sh
+++ b/Example/OpenCV-OSX-Tests/install-opencv.sh
@@ -2,8 +2,8 @@
 
 #  install-opencv.sh
 
-libraries="ilmbase snappy lame opencore-amr speex theora rtmpdump x264 x265 openssl libogg libvorbis ffmpeg jpeg libpng libtiff openexr opus"
-for package in opencv@2 $libraries; do brew link $package || brew install --ignore-dependencies $package; done
+libraries="ilmbase snappy lame opencore-amr speex theora rtmpdump x264 x265 openssl libogg libvorbis ffmpeg jpeg libpng libtiff openexr opus opencv@2"
+for package in $libraries; do brew link $package || brew install --ignore-dependencies $package; done
 
 
 # To remove all dependencies:


### PR DESCRIPTION
caching `/usr/local/opt/opencv@2/` cause directory to be created before installation of `opencv@2`
installation of `opencv@2` fails as `/usr/local/opt/opencv@2` is empty

to solve this we cache `/usr/local/opt/` which is quite small in size