### PR TITLE
Test resulting CATransform3D on expected CGRect transformations

### DIFF
--- a/Example/Tests/AccelerateSolvePerfTest.swift
+++ b/Example/Tests/AccelerateSolvePerfTest.swift
@@ -108,8 +108,8 @@ class AccelerateSolvePerfTest: XCTestCase {
 
     func transform(point: CGPoint, with transform: CATransform3D) -> CGPoint {
         let vec = simd_double4(point) * Matrix4x4(transform)
-        let w = 1.0 //vec.w != 0 ? vec.w : Double.infinity
-        return CGPoint(x: vec.x * w, y: vec.y * w)
+        let w = 1.0 // vec.w != 0 ? vec.w : Double.infinity
+        return CGPoint(x: vec.x / w, y: vec.y / w)
     }
 
     func testSimpleProjection() {

--- a/Example/Tests/AccelerateSolvePerfTest.swift
+++ b/Example/Tests/AccelerateSolvePerfTest.swift
@@ -120,7 +120,7 @@ class AccelerateSolvePerfTest: XCTestCase {
 
         let transformed = src.corners.map { transform(point: $0, with: matrix) }
         for i in 0..<src.corners.count {
-            XCTAssertEqual(src.corners[i], transformed[i])
+            XCTAssertEqual(dst.corners[i], transformed[i])
         }
     }
 }


### PR DESCRIPTION
One way to test CATransform3D resulting from PerspectiveTransform is to apply it to well known CGRects.

